### PR TITLE
Update profile.js

### DIFF
--- a/profile.js
+++ b/profile.js
@@ -85,5 +85,59 @@ function toggle() {
         shown = true;
     }
 }
+  
+//.......when "Portfolio" button is pressed, page scrolls to center image and light-box appears/..................
+
+ $("#tell-state").click(function(){
+        alert("Here's something new.");
+   $(".drop-light").show();
+    });
+
+  //.......hides light-box after scrolling up from its display area
+
+function getDocHeight() {
+    var D = document;
+    return Math.max(
+        D.body.scrollHeight, D.documentElement.scrollHeight,
+        D.body.offsetHeight, D.documentElement.offsetHeight,
+        D.body.clientHeight, D.documentElement.clientHeight
+    )
+  
+}
+
+var winheight, docheight, trackLength, throttlescroll
+
+function getmeasurements(){
+	winheight= window.innerHeight || (document.documentElement || document.body).clientHeight
+	docheight = getDocHeight()
+	trackLength = docheight - winheight
+}
+
+function amountscrolled(){
+	var scrollTop = window.pageYOffset || (document.documentElement || document.body.parentNode || document.body).scrollTop
+	var pctScrolled = Math.floor(scrollTop/trackLength * 100) // gets percentage scrolled (ie: 80 or NaN if tracklength == 0)
+	/*output.innerHTML = pctScrolled + '% scrolled'*/
+  
+ /* after drop-light becomes visible via pressing the "Portfolio button", now when you scroll up from there, it disappears, leaving only the blinking lights on the "Portfolio" button*/
+  if(pctScrolled <= 35){
+    $(".drop-light").hide();
+  }else{
+    console.log('The drop-down showed');
+  }
+}
+
+getmeasurements()
+
+window.addEventListener("resize", function(){
+	getmeasurements()
+}, false)
+
+window.addEventListener("scroll", function(){
+	clearTimeout(throttlescroll)
+		throttlescroll = setTimeout(function(){ // throttle code inside scroll to once every 50 milliseconds
+		amountscrolled()
+	}, 50)
+}, false)
+
 
 });


### PR DESCRIPTION
Added two new features: 
1. when the user clicks on the "portfolio" button (which causes an automatic scroll-down to middle of page), a box with two blinking lights appear below the animated portfolio slideshow. These lights operate the same way as the blinking lights on the "portfolio" button operates. But because the user can't see the beauty of these portfolio button's blinking animation-state lights all the time especially when you've scrolled past the button, I decided that I'll make a second version that only appears when the "portfolio" button is pressed. This is because when the "portfolio" button is pressed, the page is auto- scrolled to the portfolio section of the page, and the "portfolio button's blinking lights aren't within view. Also, now, after this, if the user scrolls back up, there will now be two sets of blinking lights visible, those of the "Portfolio" button, and those added when the "portfolio" button was pressed. I wanted to avoid having both sets of lights visible at the same time, (too busy) so,
2. I added some code to make the second set of blinking lights disappear upon scrolling back up.